### PR TITLE
Dcr8898 associations

### DIFF
--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -1,2 +1,4 @@
 class Bid < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :item
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,5 @@
 class Item < ActiveRecord::Base
-
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
+  has_many :bids
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ActiveRecord::Base
-
+  has_many :items, foreign_key: "seller_id"
+  has_many :purchases, class_name: "Item", foreign_key: "buyer_id"
+  has_many :bids
 end

--- a/db/migrate/20151205024748_rename_item_seller_to_seller_id.rb
+++ b/db/migrate/20151205024748_rename_item_seller_to_seller_id.rb
@@ -1,5 +1,7 @@
 class RenameItemSellerToSellerId < ActiveRecord::Migration
   def change
-    t.rename :seller, :seller_id
+    change_table :items do |t|
+      t.rename :seller, :seller_id
+    end
   end
 end

--- a/db/migrate/20151205024748_rename_item_seller_to_seller_id.rb
+++ b/db/migrate/20151205024748_rename_item_seller_to_seller_id.rb
@@ -1,0 +1,5 @@
+class RenameItemSellerToSellerId < ActiveRecord::Migration
+  def change
+    t.rename :seller, :seller_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,45 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20151205024748) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bids", force: :cascade do |t|
+    t.decimal  "amount",     precision: 15, scale: 2, null: false
+    t.integer  "bidder_id",                           null: false
+    t.integer  "item_id",                             null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.string   "title",                                  null: false
+    t.text     "description"
+    t.decimal  "starting_bid",  precision: 15, scale: 2
+    t.datetime "starting_date",                          null: false
+    t.datetime "end_date",                               null: false
+    t.integer  "seller_id",                              null: false
+    t.integer  "buyer_id"
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username",        null: false
+    t.string "email",           null: false
+    t.string "password_digest"
+  end
+
+end


### PR DESCRIPTION
Add a migration to rename Item.seller to Item.seller_id, per convention.
Adds all associations indicated in the schema.
Does not include a pass through association from User through Bid to Item.  We can add this later, if needed.
I will add tests later (and then validations, and then validations tests . . . :)).